### PR TITLE
Transform to array $ok_algorithms

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -415,7 +415,7 @@ final class Core
             'ripemd160', 'ripemd256', 'ripemd320', 'whirlpool',
         ];
         Core::ensureTrue(
-            \in_array($algorithm, $ok_algorithms, true),
+            \in_array($algorithm, (array) $ok_algorithms, true),
             'Algorithm is not a secure cryptographic hash function.'
         );
 


### PR DESCRIPTION
I'm using laravel with passport for authentication.
When generating a new token I get the error "Invalid opcode 117/2/0.".
I'm using sail to set up the environment.
I found that converting the variable to array when calling the in_array function solved the problem.

Don't ask me why that is. I haven't figured it out yet.

![Captura de Tela 2021-01-08 às 16 32 44](https://user-images.githubusercontent.com/31871837/104056463-4903d480-51cf-11eb-9684-dfdd7c379ec5.png)

![Captura de Tela 2021-01-08 às 16 32 59](https://user-images.githubusercontent.com/31871837/104056458-46a17a80-51cf-11eb-81d9-3e9186134413.png)
